### PR TITLE
Rename the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# woopack runner
+# projext runner
 
-A woopack plugin to run Node targets with a simple command no matter the environment, even if woopack is not installed.
+A projext plugin to run Node targets with a simple command no matter the environment, even if projext is not installed.
 
 ## Introduction
 
 This is part plugin and part stand alone tool:
 
-- When woopack present, it assumes that is on a development environment and every time a file is builded, it will write an information file.
-- If woopack is not present, it assumes that is on a production environment, and it will use the file generated while on development to run the targets.
+- When projext present, it assumes that is on a development environment and every time a file is builded, it will write an information file.
+- If projext is not present, it assumes that is on a production environment, and it will use the file generated while on development to run the targets.
 
-The idea behind this plugin-tool is that you don't have to hard code the instruction to run a target when woopack is not present; and you can install on a production environment since it doesn't depend on any of the other woopack tools.
+The idea behind this plugin-tool is that you don't have to hard code the instruction to run a target when projext is not present; and you can install on a production environment since it doesn't depend on any of the other projext tools.
 
 ## Information
 
 | -            | -                                                                                     |
 |--------------|---------------------------------------------------------------------------------------|
-| Package      | woopack-plugin-runner                                                                 |
-| Description  | A woopack plugin to run Node targets with a simple command no matter the environment. |
+| Package      | projext-plugin-runner                                                                 |
+| Description  | A projext plugin to run Node targets with a simple command no matter the environment. |
 | Node Version | >= v6.10.0                                                                            |
 
 ## Usage
@@ -25,7 +25,7 @@ The idea behind this plugin-tool is that you don't have to hard code the instruc
 
 The most important thing you need to remember is that this plugin-tool depends on a file with the information of the targets: The runner file.
 
-The runner file is called `woopackrunner.json` and it's created when you build your targets, on your project root directory. You should probably add it to your `.gitignore`.
+The runner file is called `projextrunner.json` and it's created when you build your targets, on your project root directory. You should probably add it to your `.gitignore`.
 
 If the feature to copy project files is enabled, the file will be automatically copied to the distribution directory when the files are copied; otherwise, you'll have to copy it manually before moving the distribution directory to the production environment (deploying).
 
@@ -34,13 +34,13 @@ If the feature to copy project files is enabled, the file will be automatically 
 To run the targets, the runner provides you with a CLI tool:
 
 ```bash
-woopack-runner [target] [--production]
+projext-runner [target] [--production]
 ```
 
 - `target`: The name of the target you intend to run.
-- `--production`: This forces the runner to build the target for production and run that even if woopack is present. If the option is not specified, it will check if woopack is present to determine whether it is a development or production environment.
+- `--production`: This forces the runner to build the target for production and run that even if projext is present. If the option is not specified, it will check if projext is present to determine whether it is a development or production environment.
 
-When on a development environment, this command will basically call `woopack run`, unless `--production` is used; If it is on a production environment, it will use the information of the runner file to execute the file.
+When on a development environment, this command will basically call `projext run`, unless `--production` is used; If it is on a production environment, it will use the information of the runner file to execute the file.
 
 ### Customizing the execution
 
@@ -52,20 +52,20 @@ For now, there's only one available option.
 
 ### Extending/overwriting the services
 
-Like woopack, the this plugin-tool is built using [Jimple](https://yarnpkg.com/en/package/jimple), a port of [Pimple Dependency Injection container](https://github.com/silexphp/Pimple/) for Node, and EVERYTHING is registered on a container. You can simple set your own version of a service with the same name in order to overwrite it.
+Like projext, the this plugin-tool is built using [Jimple](https://yarnpkg.com/en/package/jimple), a port of [Pimple Dependency Injection container](https://github.com/silexphp/Pimple/) for Node, and EVERYTHING is registered on a container. You can simple set your own version of a service with the same name in order to overwrite it.
 
 > If you haven't tried [Jimple](https://github.com/fjorgemota/jimple), give it a try, it's excellent for organizing your app dependencies and services.
 
-The way you get access to the container is by creating a file called `woopack.runner.js` on your project root directory, there you'll create your own instance of the runner, register your custom/overwrite services and export it:
+The way you get access to the container is by creating a file called `projext.runner.js` on your project root directory, there you'll create your own instance of the runner, register your custom/overwrite services and export it:
 
 ```js
-// woopack.runner.js
+// projext.runner.js
 
 // Get the main class
-const { WoopackRunner } = require('woopack-plugin-runner/src/app');
+const { ProjextRunner } = require('projext-plugin-runner/src/app');
 
 // Create a new instance
-const myRunner = new WoopackRunner();
+const myRunner = new ProjextRunner();
 
 // Overwrite a service
 myRunner.set('targets', () => myCustomTargetsManager);
@@ -74,7 +74,7 @@ myRunner.set('targets', () => myCustomTargetsManager);
 module.exports = myRunner;
 ```
 
-> You have to require it from `/src/app` because woopack doesn't **yet** support a named export to load a plugin, and the main export is meant to be a function used by woopack to register the plugin.
+> You have to require it from `/src/app` because projext doesn't **yet** support a named export to load a plugin, and the main export is meant to be a function used by projext to register the plugin.
 
 ## Development
 

--- a/__mocks__/projext.js
+++ b/__mocks__/projext.js
@@ -1,0 +1,7 @@
+/**
+ * This is the only way to mock a module that is not on the `package.json`.
+ * This plugin uses projext but doesn't directly depends on it: This plugin checks if it can
+ * require `projext`, if it fails, it assumes the app is on a production environment, otherwise,
+ * it's on a development environment and every run command can be sent to projext directly.
+ */
+module.exports = {};

--- a/__mocks__/woopack.js
+++ b/__mocks__/woopack.js
@@ -1,7 +1,0 @@
-/**
- * This is the only way to mock a module that is not on the `package.json`.
- * This plugin uses Woopack but doesn't directly depends on it: This plugin checks if it can
- * require `woopack`, if it fails, it assumes the app is on a production environment, otherwise,
- * it's on a development environment and every run command can be sent to Woopack directly.
- */
-module.exports = {};

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-    "name": "woopack-plugin-runner",
-    "cliName": "woopack-runner",
-    "description": "A woopack plugin to run Node targets with a simple command no matter the environment.",
-    "homepage": "https://homer0.github.io/woopack-plugin-runner/",
+    "name": "projext-plugin-runner",
+    "cliName": "projext-runner",
+    "description": "A projext plugin to run Node targets with a simple command no matter the environment.",
+    "homepage": "https://homer0.github.io/projext-plugin-runner/",
     "version": "2.0.0",
-    "repository": "homer0/woopack-plugin-runner",
+    "repository": "homer0/projext-plugin-runner",
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",
     "dependencies": {
@@ -39,8 +39,8 @@
     },
     "main": "src/index.js",
     "bin": {
-      "woopack-runner": "./src/bin/woopack-runner",
-      "woopack-runner-cli": "./src/bin/woopack-runner-cli"
+      "projext-runner": "./src/bin/projext-runner",
+      "projext-runner-cli": "./src/bin/projext-runner-cli"
     },
     "scripts": {
       "install-hooks": "./utils/hooks/install",

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -24,10 +24,10 @@ const {
 const { asPlugin } = require('../services/utils');
 /**
  * This is the plugin own dependency injection cotainer. Different from most of the other plugins,
- * this one is a little bit more complex as it is prepare to run with and without Woopack present.
+ * this one is a little bit more complex as it is prepare to run with and without projext present.
  * @extends {Jimple}
  */
-class WoopackRunner extends Jimple {
+class ProjextRunner extends Jimple {
   /**
    * Registers all the known services and add an error handler.
    * @ignore
@@ -56,21 +56,21 @@ class WoopackRunner extends Jimple {
     this._addErrorHandler();
   }
   /**
-   * This is called when Woopack is present and tries to load the plugin. It will add events
-   * listeners so every time Woopack builds a target or creates a revision file, the runner file
-   * will be updated. It also adds a listener for when Woopack copies the projects files so it
+   * This is called when projext is present and tries to load the plugin. It will add events
+   * listeners so every time projext builds a target or creates a revision file, the runner file
+   * will be updated. It also adds a listener for when projext copies the projects files so it
    * will include the runner file.
-   * @param {Woopack} woopack The Woopack main container.
+   * @param {Projext} projext The projext main container.
    */
-  plugin(woopack) {
+  plugin(projext) {
     // Get the events service.
-    const events = woopack.get('events');
+    const events = projext.get('events');
     // Adds the listener for when targets are built.
     events.once('build-target-commands-list', (commands, target) => {
       // Get the distribution directory path.
-      const distPath = woopack.get('projectConfiguration').getConfig().paths.build;
+      const distPath = projext.get('projectConfiguration').getConfig().paths.build;
       // Get the project version.
-      const version = woopack.get('buildVersion').getVersion();
+      const version = projext.get('buildVersion').getVersion();
 
       // Update the runner file.
       this.get('runnerFile').update(target, version, distPath);
@@ -80,7 +80,7 @@ class WoopackRunner extends Jimple {
        */
       return commands;
     });
-    // Adds the listener that includes the runner file on the list of files Woopack copies.
+    // Adds the listener that includes the runner file on the list of files projext copies.
     events.once('project-files-to-copy', (list) => [
       ...list,
       this.get('runnerFile').getFilename(),
@@ -112,4 +112,4 @@ class WoopackRunner extends Jimple {
   }
 }
 
-module.exports = { WoopackRunner };
+module.exports = { ProjextRunner };

--- a/src/bin/projext-runner
+++ b/src/bin/projext-runner
@@ -16,7 +16,7 @@ fi
 # If no target was specified
 if [ "$target" = "" ] || [ "$isAValidTarget" = false ]; then
   # ...show the Node CLI help information
-  woopack-runner-cli --help
+  projext-runner-cli --help
 else
   # ...otherwise, check if the task is a private helper task
   if echo "$task" | grep -q "^sh\-$"; then
@@ -32,9 +32,9 @@ else
   if [ "$isSHTask" = true ] && [ "$disableSHTasks" = false ]; then
       # ...execute a validation command to avoid any error being thrown on the
       # command that returns the list.
-      eval "woopack-runner-cli sh-validate $*"
+      eval "projext-runner-cli sh-validate $*"
       # Capture the commands that need to run
-      command=$(eval "woopack-runner-cli sh-run $*")
+      command=$(eval "projext-runner-cli sh-run $*")
       # If there are commands to run...
       if [ "$command" != "" ]; then
         # ...execute them
@@ -43,6 +43,6 @@ else
       fi
   else
     # ...otherwise, delegate everything to the Node CLI
-    woopack-runner-cli "$@"
+    projext-runner-cli "$@"
   fi
 fi

--- a/src/bin/projext-runner-cli
+++ b/src/bin/projext-runner-cli
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Get an instance of WoopackRunner to use.
- * @type {WoopackRunner}
+ * Get an instance of runner to use.
+ * @type {ProjextRunner}
  */
 const runner = require('../../index');
 // Start the CLI interface.

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 const runner = require('../index');
 /**
- * This is the method called by Woopack when loading the plugin and it takes care of calling
- * the instance of the runner and using it to register on Woopack.
- * @param {Woopack} app The Woopack main container.
+ * This is the method called by projext when loading the plugin and it takes care of calling
+ * the instance of the runner and using it to register on projext.
+ * @param {Projext} app The projext main container.
  * @ignore
  */
 const loadPlugin = (app) => runner.plugin(app);

--- a/src/services/cli/cliSHRun.js
+++ b/src/services/cli/cliSHRun.js
@@ -30,7 +30,7 @@ class CLISHRunCommand extends CLICommand {
     this.addOption(
       'production',
       '-p, --production',
-      'Force the runner to use a production build even if Woopack is present',
+      'Force the runner to use a production build even if projext is present',
       false
     );
     this.addOption(
@@ -51,7 +51,7 @@ class CLISHRunCommand extends CLICommand {
    * @param {Command} command            The executed command (sent by `commander`).
    * @param {Object}  options            The command options.
    * @param {string}  options.production If the user wants to run a production build, even with
-   *                                     Woopack preset.
+   *                                     projext preset.
    * @param {boolean} options.ready      If the user used the `production` option, then the list
    *                                     of commands will be: one to build the target for
    *                                     production and one to run this command again, because if

--- a/src/services/cli/cliSHValidate.js
+++ b/src/services/cli/cliSHValidate.js
@@ -39,7 +39,7 @@ class CLISHValidateCommand extends CLICommand {
     this.addOption(
       'production',
       '-p, --production',
-      'Force the runner to use a production build even if Woopack is present',
+      'Force the runner to use a production build even if projext is present',
       false
     );
     this.addOption(
@@ -63,7 +63,7 @@ class CLISHValidateCommand extends CLICommand {
     this.runnerFile.validate();
     /**
      * Then, if the runner file exists, validate the target, otherwise, we'll assume this is
-     * running with Woopack present and the file is going to be generated on build.
+     * running with projext present and the file is going to be generated on build.
      */
     return !this.runnerFile.exists() || this.targets.validate(target);
   }

--- a/src/services/runner/file.js
+++ b/src/services/runner/file.js
@@ -9,14 +9,14 @@ const { provider } = require('jimple');
 class RunnerFile {
   /**
    * Class constructor.
-   * @param {boolean}   asPlugin  To check if Woopack is present or not.
+   * @param {boolean}   asPlugin  To check if projext is present or not.
    * @param {Object}    info      The plugin `package.json` information, to use the plugin version
    *                              on the file.
    * @param {PathUtils} pathUtils To build the paths to the file.
    */
   constructor(asPlugin, info, pathUtils) {
     /**
-     * Whether Woopack is present or not.
+     * Whether projext is present or not.
      * @type {boolean}
      */
     this.asPlugin = asPlugin;
@@ -24,7 +24,7 @@ class RunnerFile {
      * The name of the runner file.
      * @type {string}
      */
-    this.filename = 'woopackrunner.json';
+    this.filename = 'projextrunner.json';
     /**
      * The path to the runner file.
      * @type {string}
@@ -125,12 +125,12 @@ class RunnerFile {
   }
   /**
    * Validate the runner file.
-   * @throws {Error} If the runner file doesn't exist and Woopack is not present, which means the
+   * @throws {Error} If the runner file doesn't exist and projext is not present, which means the
    *                 project was deployed to production without the runner file.
    */
   validate() {
     if (!this.asPlugin && !this.exists()) {
-      throw new Error('The runner file doesn\'t exist and woopack is not present');
+      throw new Error('The runner file doesn\'t exist and projext is not present');
     }
   }
 }

--- a/src/services/runner/runner.js
+++ b/src/services/runner/runner.js
@@ -6,14 +6,14 @@ const { provider } = require('jimple');
 class Runner {
   /**
    * Class constructor.
-   * @param {boolean}    asPlugin   To check if Woopack is present or not
+   * @param {boolean}    asPlugin   To check if projext is present or not
    * @param {PathUtils}  pathUtils  To create the path for the targets executables.
    * @param {RunnerFile} runnerFile To read the required information to run targets.
    * @param {Targets}    targets    To get the targets information.
    */
   constructor(asPlugin, pathUtils, runnerFile, targets) {
     /**
-     * Whether Woopack is present or not.
+     * Whether projext is present or not.
      * @type {boolean}
      */
     this.asPlugin = asPlugin;
@@ -36,7 +36,7 @@ class Runner {
   /**
    * Get the shell execution commands for running a target.
    * @param {string}  targetName         The name of the target to run.
-   * @param {boolean} production         In case Woopack is present, this flag forces the runner
+   * @param {boolean} production         In case projext is present, this flag forces the runner
    *                                     to build the target for production and run that build.
    * @param {string}  runAsPluginCommand In case `production` is `true`, the plugin will first run
    *                                     a build command in order to update the runner file with
@@ -47,10 +47,10 @@ class Runner {
    */
   getCommands(targetName, production, runAsPluginCommand) {
     let commands;
-    // If Woopack is present...
+    // If projext is present...
     if (this.asPlugin) {
-      // ..get the commands to run with Woopack.
-      commands = this.getCommandsForWoopack(targetName, production, runAsPluginCommand);
+      // ..get the commands to run with projext.
+      commands = this.getCommandsForProjext(targetName, production, runAsPluginCommand);
     } else {
       // ...otherwise, get the target information.
       const target = this.targets.getTarget(targetName);
@@ -69,15 +69,15 @@ class Runner {
   getPluginCommandsForProduction(targetName) {
     // Get the target information.
     const target = this.targets.getTarget(targetName);
-    // Get the commands to run without Woopack.
+    // Get the commands to run without projext.
     const commands = this.getCommandsForProduction(target);
     // Push all the commands in to a single string.
     return commands.join(';');
   }
   /**
-   * Get the list of comands to run a target with Woopack.
+   * Get the list of comands to run a target with projext.
    * @param {string}  targetName         The name of the target to run.
-   * @param {boolean} production         Forces Woopack to use the production build.
+   * @param {boolean} production         Forces projext to use the production build.
    * @param {string}  runAsPluginCommand In case `production` is `true`, the plugin will first run
    *                                     a build command in order to update the runner file with
    *                                     the latest information and then it will run this command,
@@ -85,25 +85,25 @@ class Runner {
    *                                     needs to execute it.
    * @return {Array}
    */
-  getCommandsForWoopack(targetName, production, runAsPluginCommand) {
+  getCommandsForProjext(targetName, production, runAsPluginCommand) {
     const commands = [];
     // If the target needs to use the production build...
     if (production) {
       // ...push the command to create a production build.
-      commands.push(`woopack build ${targetName} --type production`);
+      commands.push(`projext build ${targetName} --type production`);
       // Push the command to run the plugin again.
       commands.push(runAsPluginCommand);
     } else {
       // ...otherwise, get the environment variables to send.
       const variables = this.getEnvironmentVariables(this.runnerFile.read());
-      // Push the command to the target with Woopack.
-      commands.push(`${variables} woopack run ${targetName}`);
+      // Push the command to the target with projext.
+      commands.push(`${variables} projext run ${targetName}`);
     }
     // Return the list of commands.
     return commands;
   }
   /**
-   * Get the list of commands to run a target without Woopack present.
+   * Get the list of commands to run a target without projext present.
    * @param {Target} target The target information.
    * @return {Array}
    */
@@ -115,7 +115,7 @@ class Runner {
     // Get the executable it needs to use to run the target.
     const runWith = target.options.runWith || 'node';
     let execPath;
-    // If Woopack is present...
+    // If projext is present...
     if (this.asPlugin) {
       /**
        * ...this means the user is running a production build, so set the execution file from

--- a/src/services/runner/targets.js
+++ b/src/services/runner/targets.js
@@ -6,13 +6,13 @@ const { provider } = require('jimple');
 class Targets {
   /**
    * Class constructor.
-   * @param {boolean}    asPlugin   To check if Woopack is present or not
+   * @param {boolean}    asPlugin   To check if projext is present or not
    * @param {PathUtils}  pathUtils  To create the targets exeuction paths.
    * @param {RunnerFile} runnerFile To get the targets information.
    */
   constructor(asPlugin, pathUtils, runnerFile) {
     /**
-     * Whether Woopack is present or not.
+     * Whether projext is present or not.
      * @type {boolean}
      */
     this.asPlugin = asPlugin;

--- a/src/services/utils/asPlugin.js
+++ b/src/services/utils/asPlugin.js
@@ -1,18 +1,18 @@
 const { provider } = require('jimple');
 /**
- * Checks whether or not Woopack is preent on the environment.
+ * Checks whether or not projext is present on the environment.
  * @return {boolean}
  */
 const asPlugin = () => {
-  let woopackExists = true;
+  let projextExists = true;
   try {
     // eslint-disable-next-line global-require
-    require('woopack');
+    require('projext');
   } catch (ignore) {
-    woopackExists = false;
+    projextExists = false;
   }
 
-  return woopackExists;
+  return projextExists;
 };
 /**
  * The service provider that once registered on the app container will set the result of

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -4,8 +4,8 @@
  */
 
 /**
- * @external {Woopack}
- * https://homer0.github.io/woopack/class/src/app/index.js~Woopack.html
+ * @external {Projext}
+ * https://homer0.github.io/projext/class/src/app/index.js~Projext.html
  */
 
 /**
@@ -27,7 +27,7 @@
  * @property {boolean} node
  * Whether the target type is `node` or not.
  * @property {Object} options
- * The options to customize the target that will be taken from the woopack target `runnerOptions`
+ * The options to customize the target that will be taken from the projext target `runnerOptions`
  * setting.
  * @property {string} exec
  * The absolute path to the executable file. This is generated on runtime when the file is loaded,

--- a/tests/app/index.test.js
+++ b/tests/app/index.test.js
@@ -5,10 +5,10 @@ jest.unmock('/src/app/index');
 
 require('jasmine-expect');
 
-const { WoopackRunner } = require('/src/app');
+const { ProjextRunner } = require('/src/app');
 const packageInfo = require('../../package.json');
 
-describe('app:WoopackRunner', () => {
+describe('app:ProjextRunner', () => {
   beforeEach(() => {
     JimpleMock.reset();
   });
@@ -22,9 +22,9 @@ describe('app:WoopackRunner', () => {
     }));
     JimpleMock.mock('get', get);
     // When
-    sut = new WoopackRunner();
+    sut = new ProjextRunner();
     // Then
-    expect(sut).toBeInstanceOf(WoopackRunner);
+    expect(sut).toBeInstanceOf(ProjextRunner);
     expect(get).toHaveBeenCalledTimes(1);
     expect(get).toHaveBeenCalledWith('errorHandler');
     expect(listenErrors).toHaveBeenCalledTimes(1);
@@ -42,15 +42,15 @@ describe('app:WoopackRunner', () => {
     const set = jest.fn();
     JimpleMock.mock('set', set);
     // When
-    sut = new WoopackRunner();
+    sut = new ProjextRunner();
     [[infoServiceName, infoServiceFn]] = set.mock.calls;
     // Then
-    expect(sut).toBeInstanceOf(WoopackRunner);
+    expect(sut).toBeInstanceOf(ProjextRunner);
     expect(infoServiceName).toBe('info');
     expect(infoServiceFn()).toEqual(packageInfo);
   });
 
-  it('should create the runner file when a Woopack target gets build', () => {
+  it('should create the runner file when a projext target gets build', () => {
     // Given
     const updateRunnerFile = jest.fn();
     const get = jest.fn(() => ({
@@ -58,26 +58,26 @@ describe('app:WoopackRunner', () => {
       update: updateRunnerFile,
     }));
     JimpleMock.mock('get', get);
-    const woopackEvents = {
+    const projextEvents = {
       once: jest.fn(),
     };
-    const woopackProjectConfig = {
+    const projextProjectConfig = {
       paths: {
         build: 'dist',
       },
     };
-    const woopackProjectConfiguration = {
-      getConfig: jest.fn(() => woopackProjectConfig),
+    const projextProjectConfiguration = {
+      getConfig: jest.fn(() => projextProjectConfig),
     };
-    const woopackVersion = 'latest';
-    const woopackBuildVersion = {
-      getVersion: jest.fn(() => woopackVersion),
+    const projextVersion = 'latest';
+    const projextBuildVersion = {
+      getVersion: jest.fn(() => projextVersion),
     };
-    const woopack = {
-      events: woopackEvents,
-      projectConfiguration: woopackProjectConfiguration,
-      buildVersion: woopackBuildVersion,
-      get: jest.fn((service) => woopack[service]),
+    const projext = {
+      events: projextEvents,
+      projectConfiguration: projextProjectConfiguration,
+      buildVersion: projextBuildVersion,
+      get: jest.fn((service) => projext[service]),
     };
     const target = {
       name: 'some-target',
@@ -93,50 +93,50 @@ describe('app:WoopackRunner', () => {
       'buildVersion',
     ];
     // When
-    sut = new WoopackRunner();
-    sut.plugin(woopack);
-    [[, eventListener]] = woopackEvents.once.mock.calls;
+    sut = new ProjextRunner();
+    sut.plugin(projext);
+    [[, eventListener]] = projextEvents.once.mock.calls;
     result = eventListener(commands, target);
     // Then
-    expect(woopack.get).toHaveBeenCalledTimes(expectedServices.length);
+    expect(projext.get).toHaveBeenCalledTimes(expectedServices.length);
     expectedServices.forEach((service) => {
-      expect(woopack.get).toHaveBeenCalledWith(service);
+      expect(projext.get).toHaveBeenCalledWith(service);
     });
-    expect(woopackEvents.once).toHaveBeenCalledTimes([
+    expect(projextEvents.once).toHaveBeenCalledTimes([
       expectedEventName,
       'an-event-for-another test',
       'an-event-for-another test',
     ].length);
-    expect(woopackEvents.once).toHaveBeenCalledWith(
+    expect(projextEvents.once).toHaveBeenCalledWith(
       expectedEventName,
       expect.any(Function)
     );
-    expect(woopackProjectConfiguration.getConfig).toHaveBeenCalledTimes(1);
-    expect(woopackBuildVersion.getVersion).toHaveBeenCalledTimes(1);
+    expect(projextProjectConfiguration.getConfig).toHaveBeenCalledTimes(1);
+    expect(projextBuildVersion.getVersion).toHaveBeenCalledTimes(1);
     expect(updateRunnerFile).toHaveBeenCalledTimes(1);
     expect(updateRunnerFile).toHaveBeenCalledWith(
       target,
-      woopackVersion,
-      woopackProjectConfig.paths.build
+      projextVersion,
+      projextProjectConfig.paths.build
     );
     expect(result).toEqual(commands);
   });
 
-  it('should copy runner file when Woopack copies the project files', () => {
+  it('should copy runner file when projext copies the project files', () => {
     // Given
-    const runnerFileName = 'woopackrunner.json';
+    const runnerFileName = 'projextrunner.json';
     const getRunnerFileName = jest.fn(() => runnerFileName);
     const get = jest.fn(() => ({
       listen: () => {},
       getFilename: getRunnerFileName,
     }));
     JimpleMock.mock('get', get);
-    const woopackEvents = {
+    const projextEvents = {
       once: jest.fn(),
     };
-    const woopack = {
-      events: woopackEvents,
-      get: jest.fn((service) => woopack[service]),
+    const projext = {
+      events: projextEvents,
+      get: jest.fn((service) => projext[service]),
     };
     const items = ['fileA.js', 'folderB'];
     let sut = null;
@@ -149,29 +149,29 @@ describe('app:WoopackRunner', () => {
       runnerFileName,
     ];
     // When
-    sut = new WoopackRunner();
-    sut.plugin(woopack);
-    [, [, eventListener]] = woopackEvents.once.mock.calls;
+    sut = new ProjextRunner();
+    sut.plugin(projext);
+    [, [, eventListener]] = projextEvents.once.mock.calls;
     result = eventListener(items);
     // Then
-    expect(woopack.get).toHaveBeenCalledTimes(expectedServices.length);
+    expect(projext.get).toHaveBeenCalledTimes(expectedServices.length);
     expectedServices.forEach((service) => {
-      expect(woopack.get).toHaveBeenCalledWith(service);
+      expect(projext.get).toHaveBeenCalledWith(service);
     });
-    expect(woopackEvents.once).toHaveBeenCalledTimes([
+    expect(projextEvents.once).toHaveBeenCalledTimes([
       'an-event-for-another test',
       expectedEventName,
       'an-event-for-another test',
     ].length);
-    expect(woopackEvents.once).toHaveBeenCalledWith(
+    expect(projextEvents.once).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(Function)
     );
-    expect(woopackEvents.once).toHaveBeenCalledWith(
+    expect(projextEvents.once).toHaveBeenCalledWith(
       expectedEventName,
       expect.any(Function)
     );
-    expect(woopackEvents.once).toHaveBeenCalledWith(
+    expect(projextEvents.once).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(Function)
     );
@@ -179,7 +179,7 @@ describe('app:WoopackRunner', () => {
     expect(result).toEqual(expectedItems);
   });
 
-  it('should update runner file when Woopack creates a revision file', () => {
+  it('should update runner file when projext creates a revision file', () => {
     // Given
     const updateRunnerFileVersion = jest.fn();
     const get = jest.fn(() => ({
@@ -187,12 +187,12 @@ describe('app:WoopackRunner', () => {
       updateVersion: updateRunnerFileVersion,
     }));
     JimpleMock.mock('get', get);
-    const woopackEvents = {
+    const projextEvents = {
       once: jest.fn(),
     };
-    const woopack = {
-      events: woopackEvents,
-      get: jest.fn((service) => woopack[service]),
+    const projext = {
+      events: projextEvents,
+      get: jest.fn((service) => projext[service]),
     };
     const version = 'latest';
     let sut = null;
@@ -200,29 +200,29 @@ describe('app:WoopackRunner', () => {
     const expectedEventName = 'revision-file-created';
     const expectedServices = ['events'];
     // When
-    sut = new WoopackRunner();
-    sut.plugin(woopack);
-    [,, [, eventListener]] = woopackEvents.once.mock.calls;
+    sut = new ProjextRunner();
+    sut.plugin(projext);
+    [,, [, eventListener]] = projextEvents.once.mock.calls;
     eventListener(version);
     // Then
-    expect(woopack.get).toHaveBeenCalledTimes(expectedServices.length);
+    expect(projext.get).toHaveBeenCalledTimes(expectedServices.length);
     expectedServices.forEach((service) => {
-      expect(woopack.get).toHaveBeenCalledWith(service);
+      expect(projext.get).toHaveBeenCalledWith(service);
     });
-    expect(woopackEvents.once).toHaveBeenCalledTimes([
+    expect(projextEvents.once).toHaveBeenCalledTimes([
       'an-event-for-another test',
       'an-event-for-another test',
       expectedEventName,
     ].length);
-    expect(woopackEvents.once).toHaveBeenCalledWith(
+    expect(projextEvents.once).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(Function)
     );
-    expect(woopackEvents.once).toHaveBeenCalledWith(
+    expect(projextEvents.once).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(Function)
     );
-    expect(woopackEvents.once).toHaveBeenCalledWith(
+    expect(projextEvents.once).toHaveBeenCalledWith(
       expectedEventName,
       expect.any(Function)
     );
@@ -240,10 +240,10 @@ describe('app:WoopackRunner', () => {
     }));
     JimpleMock.mock('get', get);
     // When
-    sut = new WoopackRunner();
+    sut = new ProjextRunner();
     sut.cli();
     // Then
-    expect(sut).toBeInstanceOf(WoopackRunner);
+    expect(sut).toBeInstanceOf(ProjextRunner);
     expect(startCLI).toHaveBeenCalledTimes(1);
     expect(startCLI).toHaveBeenCalledWith(expect.any(Array));
   });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -6,10 +6,10 @@ require('jasmine-expect');
 const runner = require('../index');
 const plugin = require('/src/index');
 
-describe('plugin:woopackRunner', () => {
+describe('plugin:projextRunner', () => {
   it('should register all the services', () => {
     // Given
-    const app = 'woopackApp';
+    const app = 'projextApp';
     // When
     plugin(app);
     // Then

--- a/tests/services/runner/file.test.js
+++ b/tests/services/runner/file.test.js
@@ -28,7 +28,7 @@ describe('services/runner:runnerFile', () => {
       join: jest.fn((rest) => rest),
     };
     let sut = null;
-    const expectedFilename = 'woopackrunner.json';
+    const expectedFilename = 'projextrunner.json';
     const expectedFileTemplate = {
       runnerVersion: info.version,
       version: 'development',
@@ -60,7 +60,7 @@ describe('services/runner:runnerFile', () => {
     let sut = null;
     let defaultName = null;
     let nameAfterChange = null;
-    const expectedDefaultFilename = 'woopackrunner.json';
+    const expectedDefaultFilename = 'projextrunner.json';
     // When
     sut = new RunnerFile(asPlugin, info, pathUtils);
     defaultName = sut.getFilename();
@@ -336,7 +336,7 @@ describe('services/runner:runnerFile', () => {
     expect(fs.readJsonSync).toHaveBeenCalledTimes(0);
   });
 
-  it('should throw an error if the file doesn\'t exists and woopack is not present', () => {
+  it('should throw an error if the file doesn\'t exists and projext is not present', () => {
     // Given
     fs.pathExistsSync.mockImplementationOnce(() => false);
     const asPlugin = false;
@@ -352,10 +352,10 @@ describe('services/runner:runnerFile', () => {
     sut = new RunnerFile(asPlugin, info, pathUtils);
     // Then
     expect(() => sut.validate())
-    .toThrow(/The runner file doesn't exist and woopack is not present/i);
+    .toThrow(/The runner file doesn't exist and projext is not present/i);
   });
 
-  it('shouldn\'t throw an error if the file doesn\'t exists but woopack is present', () => {
+  it('shouldn\'t throw an error if the file doesn\'t exists but projext is present', () => {
     // Given
     fs.pathExistsSync.mockImplementationOnce(() => false);
     const asPlugin = true;

--- a/tests/services/runner/runner.test.js
+++ b/tests/services/runner/runner.test.js
@@ -100,7 +100,7 @@ describe('services/runner:runner', () => {
     expect(runnerFile.read).toHaveBeenCalledTimes(1);
   });
 
-  it('should return the command to run a target with Woopack on development', () => {
+  it('should return the command to run a target with projext on development', () => {
     // Given
     const asPlugin = true;
     const pathUtils = 'pathUtils';
@@ -124,7 +124,7 @@ describe('services/runner:runner', () => {
     let sut = null;
     let result = null;
     const expectedVariables = `VERSION=${file.version}`;
-    const expectedCommand = `${expectedVariables} woopack run ${targetName}`;
+    const expectedCommand = `${expectedVariables} projext run ${targetName}`;
     // When
     sut = new Runner(asPlugin, pathUtils, runnerFile, targets);
     result = sut.getCommands(targetName, production, runAsPluginCommand);
@@ -133,7 +133,7 @@ describe('services/runner:runner', () => {
     expect(targets.getTarget).toHaveBeenCalledTimes(0);
   });
 
-  it('should return the command to run a target with Woopack on production', () => {
+  it('should return the command to run a target with projext on production', () => {
     // Given
     const asPlugin = true;
     const pathUtils = 'pathUtils';
@@ -152,7 +152,7 @@ describe('services/runner:runner', () => {
     let sut = null;
     let result = null;
     const expectedCommand = [
-      `woopack build ${targetName} --type production`,
+      `projext build ${targetName} --type production`,
       runAsPluginCommand,
     ].join(';');
     // When

--- a/tests/services/utils/asPlugin.test.js
+++ b/tests/services/utils/asPlugin.test.js
@@ -14,9 +14,9 @@ describe('services/utils:asPlugin', () => {
     jest.resetModules();
   });
 
-  it('should return `true` when woopack is present', () => {
+  it('should return `true` when projext is present', () => {
     // Given
-    jest.setMock('woopack', () => ({}));
+    jest.setMock('projext', () => ({}));
     let result = null;
     // When
     result = asPlugin();
@@ -24,9 +24,9 @@ describe('services/utils:asPlugin', () => {
     expect(result).toBeTrue();
   });
 
-  it('should return `false` when woopack is not present', () => {
+  it('should return `false` when projext is not present', () => {
     // Given
-    jest.mock('woopack', () => {
+    jest.mock('projext', () => {
       throw new Error('Module not present');
     });
     let result = null;
@@ -38,7 +38,7 @@ describe('services/utils:asPlugin', () => {
 
   it('should include a provider for the DIC', () => {
     // Given
-    jest.setMock('woopack', () => ({}));
+    jest.setMock('projext', () => ({}));
     let result = null;
     const container = {
       set: jest.fn(),


### PR DESCRIPTION
### What does this PR do?

It renames the project to avoid confusion with webpack, woocommerce and WooPack Beaver Addons.

This is a breaking change because the runner file was renamed to `projextrunner.json`, so if you had it on your `.gitignore` or on your deploy script functionality, you have to update it.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```