### PR TITLE
Fix target validation and execution path

### DIFF
--- a/src/services/runner/file.js
+++ b/src/services/runner/file.js
@@ -85,7 +85,9 @@ class RunnerFile {
         targetPath = build.substr(directory.length + 1);
       }
 
-      const targetExec = target.output.production;
+      const targetExec = target.bundle ?
+        target.output.production :
+        target.entry.production;
       const targetExecPath = path.join(targetPath, targetExec);
 
       file.targets[target.name] = {

--- a/src/services/runner/targets.js
+++ b/src/services/runner/targets.js
@@ -50,7 +50,6 @@ class Targets {
    * @param  {string} name The target name.
    * @return {boolean}
    * @throws {Error} If the runner file doesn't exist.
-   * @throws {Error} If the target type is not Node.
    * @throws {Error} If the target executable doesn't exist.
    */
   validate(name) {
@@ -62,11 +61,6 @@ class Targets {
       }
 
       const target = this.getTarget(name);
-      // Check if the target type is Node.
-      if (!target.node) {
-        throw new Error(`${name} is not a Node target, it can't be used with the runner`);
-      }
-
       // Check if the target executable exists.
       if (!fs.pathExistsSync(target.exec)) {
         throw new Error(`The target executable doesn't exist: ${target.exec}`);

--- a/tests/services/runner/file.test.js
+++ b/tests/services/runner/file.test.js
@@ -108,13 +108,66 @@ describe('services/runner:runnerFile', () => {
     };
     const target = {
       name: 'backend',
-      output: {
+      entry: {
         production: 'start.js',
       },
       folders: {
         build: 'dist',
       },
       bundle: false,
+      is: {
+        node: true,
+      },
+    };
+    const version = 'latest';
+    const directory = target.folders.build;
+    let sut = null;
+    let result = null;
+    const expectedFile = {
+      runnerVersion: expect.any(String),
+      version,
+      directory,
+      targets: {
+        [target.name]: {
+          name: target.name,
+          path: target.entry.production,
+          options: {},
+        },
+      },
+    };
+    // When
+    sut = new RunnerFile(asPlugin, info, pathUtils);
+    result = sut.update(target, version, directory);
+    // Then
+    expect(result).toBe(writeResult);
+    expect(fs.pathExistsSync).toHaveBeenCalledTimes(1);
+    expect(fs.pathExistsSync).toHaveBeenCalledWith(filename);
+    expect(fs.writeJsonSync).toHaveBeenCalledTimes(1);
+    expect(fs.writeJsonSync).toHaveBeenCalledWith(filename, expectedFile);
+  });
+
+  it('should update the file with a bundled target information', () => {
+    // Given
+    fs.pathExistsSync.mockImplementationOnce(() => false);
+    const writeResult = 'done!';
+    fs.writeJsonSync.mockImplementationOnce(() => writeResult);
+    const asPlugin = 'asPlugin';
+    const info = {
+      version: '25092015',
+    };
+    const filename = '.randomrunner';
+    const pathUtils = {
+      join: jest.fn(() => filename),
+    };
+    const target = {
+      name: 'backend',
+      output: {
+        production: 'start.js',
+      },
+      folders: {
+        build: 'dist',
+      },
+      bundle: true,
       is: {
         node: true,
       },
@@ -189,7 +242,7 @@ describe('services/runner:runnerFile', () => {
     };
     const target = {
       name: 'backend',
-      output: {
+      entry: {
         production: 'start.js',
       },
       folders: {
@@ -214,7 +267,7 @@ describe('services/runner:runnerFile', () => {
       targets: {
         [target.name]: {
           name: target.name,
-          path: target.output.production,
+          path: target.entry.production,
           options: target.runnerOptions,
         },
       },
@@ -247,7 +300,7 @@ describe('services/runner:runnerFile', () => {
     const targetDirectory = 'backend';
     const target = {
       name: 'backend',
-      output: {
+      entry: {
         production: 'start.js',
       },
       folders: {
@@ -271,7 +324,7 @@ describe('services/runner:runnerFile', () => {
       targets: {
         [target.name]: {
           name: target.name,
-          path: `${targetDirectory}/${target.output.production}`,
+          path: `${targetDirectory}/${target.entry.production}`,
           options: target.runnerOptions,
         },
       },

--- a/tests/services/runner/targets.test.js
+++ b/tests/services/runner/targets.test.js
@@ -114,39 +114,6 @@ describe('services/runner:targets', () => {
     .toThrow(/The runner file doesn't exist/i);
   });
 
-  it('should throw an error when trying to run a browser target', () => {
-    // Given
-    const asPlugin = false;
-    const pathUtils = {
-      join: jest.fn((rest) => rest),
-    };
-    const targetName = 'some-target';
-    const target = {
-      name: targetName,
-      path: 'path-to-the-file',
-      node: false,
-    };
-    const file = {
-      targets: {
-        [targetName]: target,
-      },
-    };
-    const runnerFileExists = true;
-    const runnerFile = {
-      exists: jest.fn(() => runnerFileExists),
-      read: jest.fn(() => file),
-    };
-    let sut = null;
-    // When
-    sut = new Targets(asPlugin, pathUtils, runnerFile);
-    // Then
-    expect(() => sut.validate(targetName))
-    .toThrow(/is not a Node target/i);
-    expect(runnerFile.read).toHaveBeenCalledTimes(1);
-    expect(pathUtils.join).toHaveBeenCalledTimes(1);
-    expect(pathUtils.join).toHaveBeenCalledWith(target.path);
-  });
-
   it('should throw an error if a target executable doesn\'t exist', () => {
     // Given
     fs.pathExistsSync.mockImplementationOnce(() => false);
@@ -158,7 +125,6 @@ describe('services/runner:targets', () => {
     const target = {
       name: targetName,
       path: 'path-to-the-file',
-      node: true,
     };
     const file = {
       targets: {
@@ -194,7 +160,6 @@ describe('services/runner:targets', () => {
     const target = {
       name: targetName,
       path: 'path-to-the-file',
-      node: true,
     };
     const file = {
       targets: {


### PR DESCRIPTION
### What does this PR do?

#### Fix validation

Since #2 , the runner file is not longer writing information for browser targets, so there was no need to add the type of the target on the file... the thing is that I forgot to remove the validation that checks if the property `node` is `true`.

#### Fix execution path

On #2 I didn't realize that targets that are not bundled need to be executed with the name of it's entry, not its output; so the runner was working for bundled target but not for just transpiled or not bundled targets.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
