### PR TITLE
Fix runner file update method with the new output properties

### DIFF
--- a/src/services/runner/file.js
+++ b/src/services/runner/file.js
@@ -86,7 +86,7 @@ class RunnerFile {
       }
 
       const targetExec = target.bundle ?
-        target.output.production :
+        target.output.production.js :
         target.entry.production;
       const targetExecPath = path.join(targetPath, targetExec);
 

--- a/tests/services/runner/file.test.js
+++ b/tests/services/runner/file.test.js
@@ -162,7 +162,9 @@ describe('services/runner:runnerFile', () => {
     const target = {
       name: 'backend',
       output: {
-        production: 'start.js',
+        production: {
+          js: 'start.js',
+        },
       },
       folders: {
         build: 'dist',
@@ -183,7 +185,7 @@ describe('services/runner:runnerFile', () => {
       targets: {
         [target.name]: {
           name: target.name,
-          path: target.output.production,
+          path: target.output.production.js,
           options: {},
         },
       },


### PR DESCRIPTION
### What does this PR do?

When the changes of homer0/projext#8 get released, the output properties per environment of a node target will no longer be strings but a dictionary, like the one for browser targets output.

This PR fixes the method that updates the runner file with a target information so it will read the new object.

> This is breaking because is for a projext breaking change.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```