### PR TITLE
Use the runner command with the default target

### DIFF
--- a/src/bin/projext-runner
+++ b/src/bin/projext-runner
@@ -1,48 +1,33 @@
 #!/bin/sh -e
-# Get the name of the target that needs to run
-target=$1
-# To validate if the target parameter is a real name or an option
-isAValidTarget=true
 # If this flag gets to be true, the execution will be handled by the Node CLI
 disableSHTasks=false
 # Determine whether the task is a private helper task or not
 isSHTask=true
 
-# Check if the target is a valid target name or an option
-if echo "$1" | grep -q "^\(\-\)"; then
-  isAValidTarget=false
+# ...otherwise, check if the task is a private helper task
+if echo "$task" | grep -q "^sh\-$"; then
+  isSHTask=false
 fi
 
-# If no target was specified
-if [ "$target" = "" ] || [ "$isAValidTarget" = false ]; then
-  # ...show the Node CLI help information
-  projext-runner-cli --help
+# check if the task was used with a 'help' or 'version' option
+if echo "$*" | grep -q "\(\s\-\-\?\(help\|h\|version\|v\)\(\s\|$\)\)"; then
+  disableSHTasks=true
+fi
+
+# If the task is a shell task that needs commands...
+if [ "$isSHTask" = true ] && [ "$disableSHTasks" = false ]; then
+    # ...execute a validation command to avoid any error being thrown on the
+    # command that returns the list.
+    eval "projext-runner-cli sh-validate $*"
+    # Capture the commands that need to run
+    command=$(eval "projext-runner-cli sh-run $*")
+    # If there are commands to run...
+    if [ "$command" != "" ]; then
+      # ...execute them
+      # echo "> $command"
+      eval "$command"
+    fi
 else
-  # ...otherwise, check if the task is a private helper task
-  if echo "$task" | grep -q "^sh\-$"; then
-    isSHTask=false
-  fi
-
-  # check if the task was used with a 'help' or 'version' option
-  if echo "$*" | grep -q "\(\s\-\-\?\(help\|h\|version\|v\)\(\s\|$\)\)"; then
-    disableSHTasks=true
-  fi
-
-  # If the task is a shell task that needs commands...
-  if [ "$isSHTask" = true ] && [ "$disableSHTasks" = false ]; then
-      # ...execute a validation command to avoid any error being thrown on the
-      # command that returns the list.
-      eval "projext-runner-cli sh-validate $*"
-      # Capture the commands that need to run
-      command=$(eval "projext-runner-cli sh-run $*")
-      # If there are commands to run...
-      if [ "$command" != "" ]; then
-        # ...execute them
-        # echo "> $command"
-        eval "$command"
-      fi
-  else
-    # ...otherwise, delegate everything to the Node CLI
-    projext-runner-cli "$@"
-  fi
+  # ...otherwise, delegate everything to the Node CLI
+  projext-runner-cli "$@"
 fi

--- a/src/services/cli/cliSHRun.js
+++ b/src/services/cli/cliSHRun.js
@@ -47,7 +47,7 @@ class CLISHRunCommand extends CLICommand {
   }
   /**
    * Handle the execution of the command and outputs the list of commands to run.
-   * @param {string}  target             The name of the target to run.
+   * @param {?string} target             The name of the target to run.
    * @param {Command} command            The executed command (sent by `commander`).
    * @param {Object}  options            The command options.
    * @param {string}  options.production If the user wants to run a production build, even with
@@ -74,7 +74,8 @@ class CLISHRunCommand extends CLICommand {
       commands = this.runner.getPluginCommandsForProduction(target);
     } else {
       // ...otherwise, generate the command to run this for a second time.
-      const runPluginProduction = `${this.cliName} ${target} --production --ready`;
+      const targetArg = target ? `${target} ` : '';
+      const runPluginProduction = `${this.cliName} ${targetArg}--production --ready`;
       // Get the list of commands from the runner service.
       commands = this.runner.getCommands(target, production, runPluginProduction);
     }

--- a/src/services/cli/cliSHValidate.js
+++ b/src/services/cli/cliSHValidate.js
@@ -56,7 +56,7 @@ class CLISHValidateCommand extends CLICommand {
   }
   /**
    * Handle the execution of the command and validate all the arguments.
-   * @param {string} target The name of the target.
+   * @param {?string} target The name of the target.
    */
   handle(target) {
     // First let the service make its own validation.

--- a/src/services/runner/targets.js
+++ b/src/services/runner/targets.js
@@ -72,7 +72,7 @@ class Targets {
   }
   /**
    * Validate a target information.
-   * @param  {string} name The target name.
+   * @param  {?string} name The target name.
    * @return {boolean}
    * @throws {Error} If the runner file doesn't exist.
    * @throws {Error} If the target executable doesn't exist.
@@ -85,7 +85,7 @@ class Targets {
         throw new Error('The runner file doesn\'t exist, you first need to build a target');
       }
 
-      const target = this.getTarget(name);
+      const target = name ? this.getTarget(name) : this.getDefaultTarget();
       // Check if the target executable exists.
       if (!fs.pathExistsSync(target.exec)) {
         throw new Error(`The target executable doesn't exist: ${target.exec}`);
@@ -94,7 +94,11 @@ class Targets {
 
     return true;
   }
-
+  /**
+   * Add the execution path (`exec`) to a {@link Target}.
+   * @param {Target} target The target for which the execution path will be generated for.
+   * @return {Target}
+   */
   _normalizeTarget(target) {
     return Object.assign({
       exec: this.pathUtils.join(target.path),

--- a/src/services/runner/targets.js
+++ b/src/services/runner/targets.js
@@ -6,16 +6,23 @@ const { provider } = require('jimple');
 class Targets {
   /**
    * Class constructor.
-   * @param {boolean}    asPlugin   To check if projext is present or not
-   * @param {PathUtils}  pathUtils  To create the targets exeuction paths.
-   * @param {RunnerFile} runnerFile To get the targets information.
+   * @param {boolean}    asPlugin    To check if projext is present or not
+   * @param {Object}     packageInfo The project's `package.json`, necessary to get the project's
+   *                                 name and use it as the name of the default target.
+   * @param {PathUtils}  pathUtils   To create the targets exeuction paths.
+   * @param {RunnerFile} runnerFile  To get the targets information.
    */
-  constructor(asPlugin, pathUtils, runnerFile) {
+  constructor(asPlugin, packageInfo, pathUtils, runnerFile) {
     /**
      * Whether projext is present or not.
      * @type {boolean}
      */
     this.asPlugin = asPlugin;
+    /**
+     * The information of the project's `package.json`.
+     * @type {Object}
+     */
+    this.packageInfo = packageInfo;
     /**
      * A local reference for the `pathUtils` service.
      * @type {PathUtils}
@@ -41,9 +48,27 @@ class Targets {
       );
     }
 
-    return Object.assign({
-      exec: this.pathUtils.join(target.path),
-    }, target);
+    return this._normalizeTarget(target);
+  }
+  /**
+   * Returns the target with the name of project (specified on the `package.json`) and if there's
+   * no target with that name, then the first one, using a list of the targets name on alphabetical
+   * order.
+   * @return {Target}
+   * @throws {Error} If the project has no targets
+   */
+  getDefaultTarget() {
+    const { targets } = this.runnerFile.read();
+    const names = Object.keys(targets).sort();
+    let target;
+    if (names.length) {
+      const { name: projectName } = this.packageInfo;
+      target = targets[projectName] || targets[names[0]];
+    } else {
+      throw new Error('The project doesn\'t have any targets or none has been built yet');
+    }
+
+    return this._normalizeTarget(target);
   }
   /**
    * Validate a target information.
@@ -69,6 +94,12 @@ class Targets {
 
     return true;
   }
+
+  _normalizeTarget(target) {
+    return Object.assign({
+      exec: this.pathUtils.join(target.path),
+    }, target);
+  }
 }
 /**
  * The service provider that once registered on the app container will set an instance of
@@ -83,6 +114,7 @@ class Targets {
 const targets = provider((app) => {
   app.set('targets', () => new Targets(
     app.get('asPlugin'),
+    app.get('packageInfo'),
     app.get('pathUtils'),
     app.get('runnerFile')
   ));

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -29,7 +29,7 @@
  * @property {Object} options
  * The options to customize the target that will be taken from the projext target `runnerOptions`
  * setting.
- * @property {string} exec
+ * @property {?string} exec
  * The absolute path to the executable file. This is generated on runtime when the file is loaded,
  * not before.
  */

--- a/tests/mocks/cliCommand.mock.js
+++ b/tests/mocks/cliCommand.mock.js
@@ -4,7 +4,13 @@ const mocks = {
   output: jest.fn(),
 };
 
+const cliName = 'mock';
+
 class CLICommandMock {
+  static cliName() {
+    return cliName;
+  }
+
   static mock(name, mock) {
     mocks[name] = mock;
   }
@@ -20,7 +26,7 @@ class CLICommandMock {
     this.constructorMock(...args);
     this.addOption = mocks.addOption;
     this.output = mocks.output;
-    this.cliName = 'mock';
+    this.cliName = cliName;
   }
 
   getConfig(...args) {

--- a/tests/services/cli/cliSHRun.test.js
+++ b/tests/services/cli/cliSHRun.test.js
@@ -62,7 +62,30 @@ describe('services/cli:sh-run', () => {
     expect(runner.getCommands).toHaveBeenCalledWith(
       target,
       production,
-      expect.any(String)
+      `${CLICommandMock.cliName()} ${target} --production --ready`
+    );
+    expect(sut.output).toHaveBeenCalledTimes(1);
+    expect(sut.output).toHaveBeenCalledWith(runCommand);
+  });
+
+  it('should return the command to run the default target when executed', () => {
+    // Given
+    const runCommand = 'run';
+    const runner = {
+      getCommands: jest.fn(() => runCommand),
+    };
+    const production = false;
+    const ready = false;
+    let sut = null;
+    // When
+    sut = new CLISHRunCommand(runner);
+    sut.handle(null, null, { production, ready });
+    // Then
+    expect(runner.getCommands).toHaveBeenCalledTimes(1);
+    expect(runner.getCommands).toHaveBeenCalledWith(
+      null,
+      production,
+      `${CLICommandMock.cliName()} --production --ready`
     );
     expect(sut.output).toHaveBeenCalledTimes(1);
     expect(sut.output).toHaveBeenCalledWith(runCommand);

--- a/tests/services/runner/targets.test.js
+++ b/tests/services/runner/targets.test.js
@@ -252,7 +252,7 @@ describe('services/runner:targets', () => {
     expect(fs.pathExistsSync).toHaveBeenCalledWith(target.path);
   });
 
-  it('shouldn\'t throw anything if the validation passes', () => {
+  it('shouldn\'t throw anything if the validation passes for a target', () => {
     // Given
     fs.pathExistsSync.mockImplementationOnce(() => true);
     const asPlugin = false;
@@ -280,6 +280,42 @@ describe('services/runner:targets', () => {
     // When
     sut = new Targets(asPlugin, packageInfo, pathUtils, runnerFile);
     result = sut.validate(targetName);
+    // Then
+    expect(result).toBeTrue();
+    expect(runnerFile.read).toHaveBeenCalledTimes(1);
+    expect(pathUtils.join).toHaveBeenCalledTimes(1);
+    expect(pathUtils.join).toHaveBeenCalledWith(target.path);
+    expect(fs.pathExistsSync).toHaveBeenCalledTimes(1);
+    expect(fs.pathExistsSync).toHaveBeenCalledWith(target.path);
+  });
+
+  it('shouldn\'t throw anything if the validation passes for the default target', () => {
+    // Given
+    fs.pathExistsSync.mockImplementationOnce(() => true);
+    const asPlugin = false;
+    const packageInfo = 'packageInfo';
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
+    const target = {
+      name: 'some-target',
+      path: 'path-to-the-file',
+    };
+    const file = {
+      targets: {
+        [target.targetName]: target,
+      },
+    };
+    const runnerFileExists = true;
+    const runnerFile = {
+      exists: jest.fn(() => runnerFileExists),
+      read: jest.fn(() => file),
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new Targets(asPlugin, packageInfo, pathUtils, runnerFile);
+    result = sut.validate();
     // Then
     expect(result).toBeTrue();
     expect(runnerFile.read).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### What does this PR do?

On homer0/projext#12 projext added support the use of a default targets, which means that you are not longer required from specifying a target name on the `build` and `run` commands.

This PR adds the same support for the plugin, you can now run `projext-runner` without a target name and it will automatically use the new default target functionality.

### How should it be tested manually?

1. Try to run a target without specifying its name.
2. Run the tests.

### Are there any related PRs?

- homer0/projext#12