### PR TITLE
Fix the signature of the listener for the build commands

### DIFF
--- a/src/services/utils/projextPlugin.js
+++ b/src/services/utils/projextPlugin.js
@@ -64,8 +64,8 @@ class ProjextPlugin {
   registerPlugin(instance) {
     this._setInstance(instance);
     const events = this.get('events');
-    events.once('build-target-commands-list', (commands, target, options, unknownOptions) => (
-      this._updateBuildCommands(commands, target, options, unknownOptions)
+    events.once('build-target-commands-list', (commands, target, type, run, unknownOptions) => (
+      this._updateBuildCommands(commands, target, { type, run }, unknownOptions)
     ));
 
     events.once('project-files-to-copy', (list) => this._updateCopyList(list));

--- a/tests/services/utils/projextPlugin.test.js
+++ b/tests/services/utils/projextPlugin.test.js
@@ -136,7 +136,8 @@ describe('services/utils:projextPlugin', () => {
       get: jest.fn((service) => instanceServices[service]),
     };
     const commands = ['Charito', 'Maru'];
-    const options = {};
+    const type = 'development';
+    const run = false;
     const unknownOptions = {};
     let sut = null;
     let listener = null;
@@ -145,7 +146,7 @@ describe('services/utils:projextPlugin', () => {
     sut = new ProjextPlugin(info, runnerFile);
     sut.registerPlugin(instance);
     [[, listener]] = events.once.mock.calls;
-    result = listener(commands, target, options, unknownOptions);
+    result = listener(commands, target, type, run, unknownOptions);
     // Then
     expect(result).toEqual(commands);
     expect(projectConfiguration.getConfig).toHaveBeenCalledTimes(1);
@@ -207,9 +208,8 @@ describe('services/utils:projextPlugin', () => {
       get: jest.fn((service) => instanceServices[service]),
     };
     const commands = ['Charito', 'Maru'];
-    const options = {
-      type: 'production',
-    };
+    const type = 'production';
+    const run = false;
     const unknownOptions = {
       plugin: info.name,
     };
@@ -224,7 +224,7 @@ describe('services/utils:projextPlugin', () => {
     sut = new ProjextPlugin(info, runnerFile);
     sut.registerPlugin(instance);
     [[, listener]] = events.once.mock.calls;
-    result = listener(commands, target, options, unknownOptions);
+    result = listener(commands, target, type, run, unknownOptions);
     // Then
     expect(result).toEqual(expectedCommands);
     expect(projectConfiguration.getConfig).toHaveBeenCalledTimes(1);
@@ -241,7 +241,10 @@ describe('services/utils:projextPlugin', () => {
         plugin: info.name,
         target: requiredTarget,
       },
-      options,
+      {
+        type,
+        run,
+      },
       unknownOptions
     ));
   });
@@ -294,9 +297,8 @@ describe('services/utils:projextPlugin', () => {
       get: jest.fn((service) => instanceServices[service]),
     };
     const commands = ['Charito', 'Maru'];
-    const options = {
-      type: 'production',
-    };
+    const type = 'production';
+    const run = false;
     const unknownOptions = {
       plugin: info.name,
     };
@@ -311,7 +313,7 @@ describe('services/utils:projextPlugin', () => {
     sut = new ProjextPlugin(info, runnerFile);
     sut.registerPlugin(instance);
     [[, listener]] = events.once.mock.calls;
-    result = listener(commands, target, options, unknownOptions);
+    result = listener(commands, target, type, run, unknownOptions);
     // Then
     expect(result).toEqual(expectedCommands);
     expect(projectConfiguration.getConfig).toHaveBeenCalledTimes(1);
@@ -329,7 +331,10 @@ describe('services/utils:projextPlugin', () => {
           plugin: info.name,
           target: name,
         },
-        options,
+        {
+          type,
+          run,
+        },
         unknownOptions
       ));
     });


### PR DESCRIPTION
### What does this PR do?

The feature added on #14 wasn't working because the reducer event `build-target-commands-list` wasn't sending the entire options object but the options themselves as arguments.

This PR takes the arguments and just put them on an object.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```

### TODOs

On the next `projext` breaking version this will be released as it will start sending the entire object.