### PR TITLE
Fix the double program name on the build commands

### DIFF
--- a/src/services/utils/projextPlugin.js
+++ b/src/services/utils/projextPlugin.js
@@ -124,23 +124,32 @@ class ProjextPlugin {
     if (!this.isInstalled() || !this._instance) {
       throw new Error('You can\'t generate a build command if projext is not installed');
     }
-
+    // Get the environment variables to append to the command.
     const env = environmentVariables ? `${environmentVariables} ` : '';
+    // Get the service that will generate the build command.
+    const projextCLIBuildCommand = this.get('cliBuildCommand');
     /**
-     * We need to access the main `cli` service in order to get the program name, since we are
-     * accessing the build command without the CLI being triggered, so the command is not
-     * registered on the program.
+     * If the projext CLI was instantiated, the service will have the name of the program, as it
+     * gets set when the commands get registered; but if not, it means that we need to go to main
+     * CLI service and get it from there.
      */
-    const program = this.get('cli').name;
-    const command = this.get('cliBuildCommand').generate(Object.assign(
+    let program = '';
+    if (!projextCLIBuildCommand.cliName) {
+      const cliName = this.get('cli').name;
+      program = `${cliName} `;
+    }
+    // Generate the build command
+    const command = projextCLIBuildCommand.generate(Object.assign(
       {
         target: '',
         [this._pluginFlagName]: this.pluginName,
       },
       args
     )).trim();
-
-    return `${env}${program} ${command}`;
+    // Prepend the environment variables and the program name, if needed.
+    const result = `${env}${program}${command}`;
+    // Return the final command.
+    return result;
   }
   /**
    * Set the projext instance.

--- a/tests/services/utils/projextPlugin.test.js
+++ b/tests/services/utils/projextPlugin.test.js
@@ -279,18 +279,15 @@ describe('services/utils:projextPlugin', () => {
     const events = {
       once: jest.fn(),
     };
-    const cli = {
-      name: 'projext',
-    };
     const command = 'run projext run';
     const cliBuildCommand = {
+      cliName: 'projextFromCommand',
       generate: jest.fn((data) => `${command} ${data.target}`),
     };
     const instanceServices = {
       events,
       projectConfiguration,
       buildVersion,
-      cli,
       cliBuildCommand,
     };
     const instance = {
@@ -306,7 +303,7 @@ describe('services/utils:projextPlugin', () => {
     let listener = null;
     let result = null;
     const expectedCommands = [
-      ...target.options.build.map((name) => `${cli.name} ${command} ${name}`),
+      ...target.options.build.map((name) => `${command} ${name}`),
       ...commands,
     ];
     // When


### PR DESCRIPTION
### What does this PR do?

When generating the build commands for _"dependency targets"_, since all was being done by the hooks of the projext CLI, the interface was instantiated, so the command already had the program name (`cliName`), and because the plugin was adding it, the commands ended with `projext projext ...`.

This PR adds a check that verifies if the CLI is instantiated and if not, then it prepends the program name (obtained from the main CLI service) to the command.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
