### PR TITLE
feat(bin/projext-runner): add log messages for all the steps

### DIFF
--- a/src/bin/projext-runner
+++ b/src/bin/projext-runner
@@ -1,4 +1,28 @@
 #!/bin/sh -e
+
+# Logs an information message (dark gray)
+projextRunnerCLIInfoLog() {
+  echo "\033[90m[projext-runner] $1\033[39m"
+}
+
+# Logs a success message (green)
+projextRunnerCLISuccessLog() {
+  echo "\033[32m[projext-runner] $*\033[39m"
+}
+
+# Logs a message that indicates a task is starting (yellow)
+projextRunnerCLIStartTaskLog() {
+  echo "\033[33m[projext-runner] $1\033[39m"
+}
+
+# Logs a message that indicates a task was completed (green), and replaces the last logged
+# message
+projextRunnerCLICompleteTaskLog() {
+  echo "\033[2A";
+  printf "\033[0K\r\033[32m[projext-runner] %s\033[39m" "$*"
+  echo ""
+}
+
 # If this flag gets to be true, the execution will be handled by the Node CLI
 disableSHTasks=false
 # Determine whether the task is a private helper task or not
@@ -16,13 +40,19 @@ fi
 
 # If the task is a shell task that needs commands...
 if [ "$isSHTask" = true ] && [ "$disableSHTasks" = false ]; then
+    projextRunnerCLISuccessLog "Runner started"
     # ...execute a validation command to avoid any error being thrown on the
     # command that returns the list.
+    projextRunnerCLIStartTaskLog "Validating the command"
     eval "projext-runner-cli sh-validate $*"
+    projextRunnerCLICompleteTaskLog "Command validated"
     # Capture the commands that need to run
+    projextRunnerCLIStartTaskLog "Loading instructions for target"
     command=$(eval "projext-runner-cli sh-run $*")
     # If there are commands to run...
     if [ "$command" != "" ]; then
+      projextRunnerCLICompleteTaskLog "Target instructions loaded"
+      projextRunnerCLIInfoLog "Executing the target"
       # ...execute them
       # echo "> $command"
       eval "$command"

--- a/src/bin/projext-runner
+++ b/src/bin/projext-runner
@@ -45,7 +45,7 @@ if [ "$isSHTask" = true ] && [ "$disableSHTasks" = false ]; then
     # command that returns the list.
     projextRunnerCLIStartTaskLog "Validating the command"
     eval "projext-runner-cli sh-validate $*"
-    projextRunnerCLICompleteTaskLog "Command validated"
+    projextRunnerCLISuccessLog "Command validated"
     # Capture the commands that need to run
     projextRunnerCLIStartTaskLog "Loading instructions for target"
     command=$(eval "projext-runner-cli sh-run $*")


### PR DESCRIPTION
### What does this PR do?

> This comes from homer0/projext#79.
>
> This has been bothering me for some time now: the bin commands are SLOW. My theory is that the problem is a mix of `sync` calls on the file system and [`commander`](https://yarnpkg.com/en/package/commander).
>
> On the long run, the idea is to fix those issues (go async when possible and replace `commander`), but for now, I added more log mesages on the binary so you can at least know what's happening while you wait.

So, I applied the same logic to the runner binary.

### How should it be tested manually?

In order to test this, you need to install `homer0/projext#next`.

Checkout the branch and try running a target, you'll see step by step what the runner and projext are doing.