### PR TITLE
v9.0.2: fix: send the unknownOptions object even if is empt

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "cliName": "projext-runner",
   "description": "A projext plugin to run Node targets with a simple command no matter the environment.",
   "homepage": "https://homer0.github.io/projext-plugin-runner/",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "repository": "homer0/projext-plugin-runner",
   "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
   "license": "MIT",

--- a/src/abstracts/cliCommand.js
+++ b/src/abstracts/cliCommand.js
@@ -1,7 +1,7 @@
 /**
  * A helper class for creating commands for the CLI.
  * @abstract
- * @version 2.0
+ * @version 2.1
  */
 class CLICommand {
   /**
@@ -329,9 +329,9 @@ class CLICommand {
     // Add the new options dictionary.
     useArgs.push(options);
 
-    // If the method supports unknown options, add them as the last argument.
-    if (this.allowUnknownOptions && unknownArgs) {
-      useArgs.push(this._parseArgs(unknownArgs));
+    // If the method supports unknown options.
+    if (this.allowUnknownOptions) {
+      useArgs.push(unknownArgs ? this._parseArgs(unknownArgs) : {});
     }
     // Call the abstract method that handles the execution.
     this.handle(...useArgs);

--- a/tests/abstracts/cliCommand.test.js
+++ b/tests/abstracts/cliCommand.test.js
@@ -628,9 +628,54 @@ describe('abstracts:CLICommand', () => {
     );
   });
 
+  it('should receive an unknown options object if the command supports them', () => {
+    // Given
+    const program = {
+      command: jest.fn(() => program),
+      description: jest.fn(() => program),
+      option: jest.fn(() => program),
+      action: jest.fn(() => program),
+      allowUnknownOption: jest.fn(),
+      parseOptions: jest.fn(() => ({
+        unknown: [],
+      })),
+      helpInformation: jest.fn(),
+    };
+    const cli = {
+      name: 'some-program',
+    };
+    const command = 'test-command';
+    const description = 'Test description';
+    const allowUnknownOptions = true;
+    const handle = jest.fn();
+    const handlerArgs = [{}];
+    class Sut extends CLICommand {}
+    let sut = null;
+    let handler = null;
+    // When
+    sut = new Sut();
+    sut.command = command;
+    sut.description = description;
+    sut.allowUnknownOptions = allowUnknownOptions;
+    sut.handle = handle;
+    sut.register(program, cli);
+    [[handler]] = program.action.mock.calls;
+    handler(...handlerArgs);
+    // Then
+    expect(sut.cliName).toBe(cli.name);
+    expect(program.command).toHaveBeenCalledTimes(1);
+    expect(program.command).toHaveBeenCalledWith(command, '', {});
+    expect(program.description).toHaveBeenCalledTimes(1);
+    expect(program.description).toHaveBeenCalledWith(description);
+    expect(program.action).toHaveBeenCalledTimes(1);
+    expect(program.action).toHaveBeenCalledWith(expect.any(Function));
+    expect(program.parseOptions).toHaveBeenCalledTimes(0);
+    expect(handle).toHaveBeenCalledTimes(1);
+    expect(handle).toHaveBeenCalledWith({}, {}, {});
+  });
+
   it('should receive unknown options, normalize them and send them to the handle method', () => {
     // Given
-    //
     const unknownArgs = [
       '--include=something',
       '-i',


### PR DESCRIPTION
### What does this PR do?

Follow up for #45 - When I fixed the `CLICommand` class, I made it so it would only send the "unknown options" object if there was at least one... but the commands that allow these options are always expecting the object, even if its empty.

So the fix was to check if the command supports unknown options and, if there are options, parse them and send them; otherwise, just send an empty object.

### How should it be tested manually?

Try to use with `projext@8.0.1` and you'll see what happens :P.